### PR TITLE
Pin azure below 5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 0.4.3
+
+- Pin azure to <5.0 so we don't have to refactor to use the azure-mgmt-compute,
+  azure-mgmt-storage, azure-mgmt-resource, azure-keyvault-secrets, and
+  azure-storage-blob packages separately - see
+  https://github.com/Azure/azure-sdk-for-python/issues/10646 for more
+
 ## 0.4.2
 
 - Pin libcloud to <3.0.0 to maintain Python 2 support

--- a/pack.yaml
+++ b/pack.yaml
@@ -11,7 +11,7 @@ keywords:
   - virtual machines
   - azure virtual machines
   - azurerm 
-version: 0.4.2
+version: 0.4.3
 author : StackStorm, Inc.
 email : info@stackstorm.com
 python_versions:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 azurerm==0.8.27
 azure-mgmt==0.30.0a1
 msrestazure
-azure
+azure<5.0
 apache-libcloud<3.0.0


### PR DESCRIPTION
In version 5, the `azure` metapackage now refuses to install. The `azure` package was broken up into a bunch of smaller packages, so eventually we will need to install only the packages that we need. But for now, this PR pins the `azure` package to below 5 to keep pack CI passing.

More information on the azure change is here: Azure/azure-sdk-for-python#10646.